### PR TITLE
Adding missing Parameters map in ServiceCreationRequest structure.

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -2,11 +2,12 @@ package cf
 
 // ServiceCreationRequest describes Cloud Foundry service provisioning request
 type ServiceCreationRequest struct {
-	InstanceID       string `json:"-"`
-	ServiceID        string `json:"service_id"`
-	PlanID           string `json:"plan_id"`
-	OrganizationGUID string `json:"organization_guid"`
-	SpaceGUID        string `json:"space_guid"`
+	InstanceID       string            `json:"-"`
+	ServiceID        string            `json:"service_id"`
+	PlanID           string            `json:"plan_id"`
+	OrganizationGUID string            `json:"organization_guid"`
+	SpaceGUID        string            `json:"space_guid"`
+	Parameters       map[string]string `json:parameters`
 }
 
 // ServiceCreationResponse describes Cloud Foundry service provisioning response


### PR DESCRIPTION
For reference please look at https://docs.cloudfoundry.org/services/api.html
Subject: Provisioning:Request

"Cloud Foundry API clients can provide a JSON object of configuration parameters with
their request and this value will be passed through to the service broker. Brokers are responsible for validation."
