### PR TITLE
Omitting empty syslog_drain_url when marshalling ServiceBindingResponse.

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -27,7 +27,7 @@ type ServiceBindingRequest struct {
 // ServiceBindingResponse describes Cloud Foundry service binding response
 type ServiceBindingResponse struct {
 	Credentials    map[string]string `json:"credentials"`
-	SyslogDrainURL string            `json:"syslog_drain_url"`
+	SyslogDrainURL string            `json:"syslog_drain_url,omitempty"`
 }
 
 type ServiceLastOperationResponse struct {


### PR DESCRIPTION
Background:
If the broker does not include "requires: syslog_drain", and the bind request returns a value for syslog_drain_url, Cloud Foundry will return an error for the bind operation.

Source:
http://docs.cloudfoundry.org/services/app-log-streaming.html
