### PR TITLE
add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/cloudfoundry-community/types-cf
+
+go 1.12


### PR DESCRIPTION
Hello,
With our self-hosted  jfrog artifactory as GOPROXY, we are faced with a problem.
jfrog artifactory doesn't support module that doesn't have go.mod with error `https://[...]/github.com/cloudfoundry-community/types-cf/@v/v0.0.0-20181031222831-72ad36dcacae.mod: 404 Not Found`.
Could you accept this PR?

Thx in advance